### PR TITLE
Fixes #13. Adds additional control command to be used on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "keywords": ["pencilblue", "cms", "cli", "install"],
   "preferGlobal": "true",
   "bin": {
-    "pencilblue": "lib/pencilblue-cli.js"
+    "pencilblue": "lib/pencilblue-cli.js",
+    "pbctrl": "lib/pencilblue-cli.js"
   },
   "dependencies": {
     "shelljs": "^0.3.0",


### PR DESCRIPTION
Adds additional control command to be used on windows that does not conflict with the "pencilblue.js" executable
