### PR TITLE
Added supervisor to list of start methods

### DIFF
--- a/lib/LaunchService.js
+++ b/lib/LaunchService.js
@@ -86,6 +86,10 @@ LaunchService.launchViaForever = function() {
     return shell.exec('forever start pencilblue.js');
 };
 
+LaunchService.launchViaSupervisor = function() {
+    return shell.exec('supervisor start pencilblue.js');
+};
+
 LaunchService.isInstalled = function(method) {
     return shell.which(method) ? true : false;
 };
@@ -118,7 +122,8 @@ LaunchService.installModule = function(method) {
 var LAUNCH_TYPES = Object.freeze({
     nodemon: LaunchService.launchViaNodemon,
     node: LaunchService.launchViaNode,
-    forever: LaunchService.launchViaForever
+    forever: LaunchService.launchViaForever,
+    supervisor: LaunchService.launchViaSupervisor
 });
 
 module.exports = LaunchService;


### PR DESCRIPTION
I found that I must restart after most edits. Using supervisor helps avoid the extra steps of restarting. Not sure why nodemon wasn't doing the trick for me so I added supervisor which I normally use.